### PR TITLE
"Strict" flag to override error in production environment

### DIFF
--- a/lib/generateConfig.js
+++ b/lib/generateConfig.js
@@ -5,7 +5,7 @@ const { promises: fsp } = require('fs');
 
 const runtimeConfig = {};
 
-async function generateConfig({ envConfig, envFile }) {
+async function generateConfig({ envConfig, envFile, strict = null }) {
   let envConfigExists = true;
 
   try {
@@ -25,6 +25,7 @@ async function generateConfig({ envConfig, envFile }) {
     throw err;
   }
 
+  const isRelaxed = strict == null ? process.env.NODE_ENV === recConstants.DEVELOPMENT : !strict;
   const content = await fsp.readFile(envFile, 'utf8');
 
   content.split(/\r?\n/)
@@ -33,12 +34,13 @@ async function generateConfig({ envConfig, envFile }) {
       const equalSignIndex = line.indexOf('=');
       const lengthOfString = line.length;
 
+
       if (equalSignIndex !== -1) {
         const key = line.slice(0, equalSignIndex);
         const value = line.slice(equalSignIndex + 1, lengthOfString);
 
-        if (process.env.NODE_ENV === recConstants.DEVELOPMENT) {
-          runtimeConfig[key] = value;
+        if (isRelaxed) {
+          runtimeConfig[key] = process.env[key] ?? value;
         } else {
           if (!process.env[key])
             throw new Error(`Error getting '${key}' from process.env`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+
 const yargs = require('yargs');
 
 const generateConfig = require('./generateConfig');
@@ -17,6 +18,11 @@ const argv = yargs
     description: 'Location and name of your .env file.',
     default: './.env',
     type: 'string',
+  }).option('strict', {
+    alias: 's',
+    'description': "Raise error if matching environment variables for .env variable",
+    'default': null,
+    'type': 'boolean'
   })
   .help()
   .alias('help', 'h').argv;
@@ -25,11 +31,13 @@ const argv = yargs
   try {
     const envConfig = argv['config-name'];
     const envFile = argv['env-file'];
+    const strict = argv['strict'];
 
     console.log(`
   Provided flags:
     --config-name = ${envConfig}
     --env-file = ${envFile}
+    --strict = ${strict}
 
   Your environment variables will be available on '${constants.runtimeConfigPath}'
   `);
@@ -40,6 +48,7 @@ const argv = yargs
       result = await generateConfig({
         envConfig,
         envFile,
+        strict
       });
     } catch (err) {
       throw new Error(err.message);

--- a/tests/generateConfig.spec.js
+++ b/tests/generateConfig.spec.js
@@ -66,9 +66,8 @@ describe('runtime-env-cra', () => {
     );
   });
 
-  it('should throw error if NODE_ENV is production and env var is not found in shell', async () => {
+  it('should throw error if NODE_ENV is production, env var is not found in shell, and strict is not set', async () => {
     process.env.NODE_ENV = 'production';
-
     let config;
     let error;
 
@@ -84,6 +83,66 @@ describe('runtime-env-cra', () => {
     expect(config).toBeUndefined();
     expect(error).toBeDefined();
     expect(error.message).toEqual('Error getting \'TEST_VAR\' from process.env');
+  });
+
+  it('should default to env if NODE_ENV is production, env var is not found in shell, and strict is set to false', async () => {
+    process.env.NODE_ENV = 'production';
+
+    let config;
+    let error;
+
+    try {
+      config = await generateConfig({
+        envConfig: './tests/utils/runtime-config.js',
+        envFile: './tests/utils/.env',
+        strict: false
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeUndefined();
+    expect(config).toBeDefined();
+    expect(config).toEqual(
+      'window.__RUNTIME_CONFIG__ = {"TEST_VAR":"TEST_VALUE"};',
+    );
+  });
+
+  it('should throw error if env var is not found in shell, and strict is true regardless of environment', async () => {
+    process.env.NODE_ENV = 'development';
+
+    let config;
+    let error;
+
+    try {
+      config = await generateConfig({
+        envConfig: './tests/utils/runtime-config.js',
+        envFile: './tests/utils/.env',
+        strict: true
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(config).toBeUndefined();
+    expect(error).toBeDefined();
+    expect(error.message).toEqual('Error getting \'TEST_VAR\' from process.env');
+  });
+
+  it('should generate a runtime-config.js file successfully on Production', async () => {
+    process.env.NODE_ENV = 'Production';
+    process.env.TEST_VAR = 'TEST_VALUE';
+
+
+    config = await generateConfig({
+      envConfig: './tests/utils/runtime-config.js',
+      envFile: './tests/utils/.env',
+    });
+
+    expect(config).toBeDefined();
+    expect(config).toEqual(
+      'window.__RUNTIME_CONFIG__ = {"TEST_VAR":"TEST_VALUE"};',
+    );
   });
 
   it('should parse the TEST_VAR value from the shell when NODE_ENV is not set to development', async () => {


### PR DESCRIPTION
Fixes #10 

I have a similar use-case to the issue mentioned in #10 and in an effort to reduce additional dependences, such as [env-cmd](https://www.npmjs.com/package/env-cmd),  opted to alter this code to provide a "non-strict" option to production builds. 
I've added a boolean flag "--strict" or "-s" to allow production builds to use the default values provided in the `.env` file.

I believe this adds two key uses:
- The option to default to existing values in cases where that variable may not always be provided
- The ability to specify environmental variable overrides of the .env for local runs, and observe the effect in a development build.

I also added in a test for a line in production builds that was previously uncovered.
