### PR TITLE
updated variable value comparator

### DIFF
--- a/lib/generateConfig.js
+++ b/lib/generateConfig.js
@@ -40,7 +40,7 @@ async function generateConfig({ envConfig, envFile }) {
         if (process.env.NODE_ENV === recConstants.DEVELOPMENT) {
           runtimeConfig[key] = value;
         } else {
-          if (!process.env[key])
+          if (process.env[key] === undefined)
             throw new Error(`Error getting '${key}' from process.env`);
           runtimeConfig[key] = process.env[key];
         }


### PR DESCRIPTION
Currently, setting a variable as an empty string throws an error, this PR fixes that.

```node
> const VAR = "";
> !VAR;
true
> VAR === undefined;
false
```